### PR TITLE
Internal Statsite Metrics

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,5 +29,7 @@ COPY --from=builder /usr/local/share/statsite/ /usr/local/share/statsite/
 # You'll need to mount your configuration in here.
 VOLUME /etc/statsite
 
+EXPOSE 8125
+
 ENTRYPOINT ["/usr/local/bin/statsite"]
 CMD ["-f","/etc/statsite/statsite.conf"]

--- a/src/config.c
+++ b/src/config.c
@@ -44,6 +44,7 @@ static const statsite_config DEFAULT_CONFIG = {
     "/var/run/statsite.pid", // Default pidfile path
     0,                  // Do not use binary output by default
     NULL,               // Do not track number of messages received
+    NULL,               // Do not export internal metrics
     NULL,               // No histograms by default
     NULL,
     0.02,               // 2% goal uses precision 12
@@ -359,6 +360,8 @@ static int config_callback(void* user, const char* section, const char* name, co
         config->pid_file = strdup(value);
     } else if (NAME_MATCH("input_counter")) {
         config->input_counter = strdup(value);
+    } else if (NAME_MATCH("internal_metrics_prefix")) {
+        config->internal_metrics_prefix = strdup(value);
     } else if (NAME_MATCH("bind_address")) {
         config->bind_address = strdup(value);
     } else if (NAME_MATCH("global_prefix")) {

--- a/src/config.h
+++ b/src/config.h
@@ -63,6 +63,7 @@ typedef struct {
     char *pid_file;
     bool binary_stream;
     char *input_counter;
+    char *internal_metrics_prefix;
     histogram_config *hist_configs;
     radix_tree *histograms;
     double set_eps;

--- a/src/metrics.h
+++ b/src/metrics.h
@@ -75,7 +75,7 @@ int destroy_metrics(metrics *m);
  * @arg sample_rate The sample rate of val
  * @return 0 on success.
  */
-int metrics_add_sample(metrics *m, metric_type type, char *name, double val, double sample_rate);
+int metrics_add_sample(metrics *m, metric_type type, char *name, double val, double sample_rate, char* internal_metrics_prefix);
 
 /**
  * Adds a value to a named set.

--- a/tests/test_config.c
+++ b/tests/test_config.c
@@ -23,6 +23,7 @@ static void check_default_config(statsite_config config) {
     fail_unless(config.binary_stream == false);
     fail_unless(strcmp(config.pid_file, "/var/run/statsite.pid") == 0);
     fail_unless(config.input_counter == NULL);
+    fail_unless(config.internal_metrics_prefix == NULL);
     fail_unless(config.extended_counters == false);
     fail_unless(config.legacy_extended_counters == true);
     fail_unless(config.timers_config.count == true);
@@ -95,6 +96,7 @@ log_facility = local3\n\
 daemonize = true\n\
 binary_stream = true\n\
 input_counter = foobar\n\
+internal_metrics_prefix = baz\n\
 pid_file = /tmp/statsite.pid\n\
 extended_counters = true\n\
 prefix_binary_stream = true\n\
@@ -121,6 +123,7 @@ quantiles = 0.5, 0.90, 0.95, 0.99\n";
     fail_unless(config.binary_stream == true);
     fail_unless(strcmp(config.pid_file, "/tmp/statsite.pid") == 0);
     fail_unless(strcmp(config.input_counter, "foobar") == 0);
+    fail_unless(strcmp(config.internal_metrics_prefix, "baz") == 0);
     fail_unless(config.extended_counters == true);
     fail_unless(config.prefix_binary_stream == true);
     fail_unless(config.num_quantiles == 4);
@@ -308,6 +311,7 @@ log_facility = local0\n\
 daemonize = true\n\
 binary_stream = true\n\
 input_counter = foobar\n\
+internal_metrics_prefix = baz\n\
 pid_file = /tmp/statsite.pid\n\
 \n\
 [histogram_n1]\n\
@@ -348,6 +352,7 @@ width=25\n\
     fail_unless(config.binary_stream == true);
     fail_unless(strcmp(config.pid_file, "/tmp/statsite.pid") == 0);
     fail_unless(strcmp(config.input_counter, "foobar") == 0);
+    fail_unless(strcmp(config.internal_metrics_prefix, "baz") == 0);
 
     histogram_config *c = config.hist_configs;
     fail_unless(c != NULL);
@@ -504,6 +509,7 @@ log_facility = level0\n\
 daemonize = true\n\
 binary_stream = true\n\
 input_counter = foobar\n\
+internal_metrics_prefix = baz\n\
 pid_file = /tmp/statsite.pid\n\
 global_prefix = statsd.\n\
 use_type_prefix = 1\n\
@@ -535,6 +541,7 @@ sets_prefix=foo.sets.bar.";
     fail_unless(config.binary_stream == true);
     fail_unless(strcmp(config.pid_file, "/tmp/statsite.pid") == 0);
     fail_unless(strcmp(config.input_counter, "foobar") == 0);
+    fail_unless(strcmp(config.internal_metrics_prefix, "baz") == 0);
 
     // Values from config
     fail_unless(strcmp(config.prefixes_final[KEY_VAL], "statsd.keyvalue.") == 0);
@@ -564,6 +571,7 @@ log_facility = local3\n\
 daemonize = true\n\
 binary_stream = true\n\
 input_counter = foobar\n\
+internal_metrics_prefix = baz\n\
 pid_file = /tmp/statsite.pid\n\
 extended_counters = true\n\
 legacy_extended_counters = false\n\
@@ -591,6 +599,7 @@ quantiles = 0.5, 0.90, 0.95, 0.99\n";
     fail_unless(config.binary_stream == true);
     fail_unless(strcmp(config.pid_file, "/tmp/statsite.pid") == 0);
     fail_unless(strcmp(config.input_counter, "foobar") == 0);
+    fail_unless(strcmp(config.internal_metrics_prefix, "baz") == 0);
     fail_unless(config.extended_counters == true);
     fail_unless(config.legacy_extended_counters == false);
     // Only the count extended counter should be included

--- a/tests/test_metrics.c
+++ b/tests/test_metrics.c
@@ -67,7 +67,7 @@ START_TEST(test_metrics_add_iter)
     fail_unless(res == 0);
 
     int okay = 0;
-    fail_unless(metrics_add_sample(&m, KEY_VAL, "test", 100, 1.0) == 0);
+    fail_unless(metrics_add_sample(&m, KEY_VAL, "test", 100, 1.0, "prefix") == 0);
     fail_unless(metrics_iter(&m, (void*)&okay, iter_test_cb) == 0);
     fail_unless(okay == 1);
 
@@ -117,20 +117,20 @@ START_TEST(test_metrics_add_all_iter)
     int res = init_metrics_defaults(&m);
     fail_unless(res == 0);
 
-    fail_unless(metrics_add_sample(&m, KEY_VAL, "test", 100, 1.0) == 0);
-    fail_unless(metrics_add_sample(&m, KEY_VAL, "test2", 42, 1.0) == 0);
+    fail_unless(metrics_add_sample(&m, KEY_VAL, "test", 100, 1.0, "prefix") == 0);
+    fail_unless(metrics_add_sample(&m, KEY_VAL, "test2", 42, 1.0, "prefix") == 0);
 
-    fail_unless(metrics_add_sample(&m, GAUGE, "g1", 1, 1.0) == 0);
-    fail_unless(metrics_add_sample(&m, GAUGE, "g1", 200, 1.0) == 0);
-    fail_unless(metrics_add_sample(&m, GAUGE, "g2", 42, 1.0) == 0);
+    fail_unless(metrics_add_sample(&m, GAUGE, "g1", 1, 1.0, "prefix") == 0);
+    fail_unless(metrics_add_sample(&m, GAUGE, "g1", 200, 1.0, "prefix") == 0);
+    fail_unless(metrics_add_sample(&m, GAUGE, "g2", 42, 1.0, "prefix") == 0);
 
-    fail_unless(metrics_add_sample(&m, COUNTER, "foo", 4, 1.0) == 0);
-    fail_unless(metrics_add_sample(&m, COUNTER, "foo", 6, 1.0) == 0);
-    fail_unless(metrics_add_sample(&m, COUNTER, "bar", 10, 1.0) == 0);
-    fail_unless(metrics_add_sample(&m, COUNTER, "bar", 20, 1.0) == 0);
+    fail_unless(metrics_add_sample(&m, COUNTER, "foo", 4, 1.0, "prefix") == 0);
+    fail_unless(metrics_add_sample(&m, COUNTER, "foo", 6, 1.0, "prefix") == 0);
+    fail_unless(metrics_add_sample(&m, COUNTER, "bar", 10, 1.0, "prefix") == 0);
+    fail_unless(metrics_add_sample(&m, COUNTER, "bar", 20, 1.0, "prefix") == 0);
 
-    fail_unless(metrics_add_sample(&m, TIMER, "baz", 1, 1.0) == 0);
-    fail_unless(metrics_add_sample(&m, TIMER, "baz", 10, 1.0) == 0);
+    fail_unless(metrics_add_sample(&m, TIMER, "baz", 1, 1.0, "prefix") == 0);
+    fail_unless(metrics_add_sample(&m, TIMER, "baz", 10, 1.0, "prefix") == 0);
 
     fail_unless(metrics_set_update(&m, "zip", "foo") == 0);
     fail_unless(metrics_set_update(&m, "zip", "wow") == 0);
@@ -176,15 +176,15 @@ START_TEST(test_metrics_histogram)
     res = init_metrics(0.01, (double*)&quants, 3, config.histograms, 12, &m);
     fail_unless(res == 0);
 
-    fail_unless(metrics_add_sample(&m, TIMER, "baz", 1, 1.0) == 0);
-    fail_unless(metrics_add_sample(&m, TIMER, "baz", 10, 1.0) == 0);
-    fail_unless(metrics_add_sample(&m, TIMER, "baz", -1, 1.0) == 0);
-    fail_unless(metrics_add_sample(&m, TIMER, "baz", 50, 1.0) == 0);
+    fail_unless(metrics_add_sample(&m, TIMER, "baz", 1, 1.0, "prefix") == 0);
+    fail_unless(metrics_add_sample(&m, TIMER, "baz", 10, 1.0, "prefix") == 0);
+    fail_unless(metrics_add_sample(&m, TIMER, "baz", -1, 1.0, "prefix") == 0);
+    fail_unless(metrics_add_sample(&m, TIMER, "baz", 50, 1.0, "prefix") == 0);
 
-    fail_unless(metrics_add_sample(&m, TIMER, "zip", 1, 1.0) == 0);
-    fail_unless(metrics_add_sample(&m, TIMER, "zip", 10, 1.0) == 0);
-    fail_unless(metrics_add_sample(&m, TIMER, "zip", -1, 1.0) == 0);
-    fail_unless(metrics_add_sample(&m, TIMER, "zip", 50, 1.0) == 0);
+    fail_unless(metrics_add_sample(&m, TIMER, "zip", 1, 1.0, "prefix") == 0);
+    fail_unless(metrics_add_sample(&m, TIMER, "zip", 10, 1.0, "prefix") == 0);
+    fail_unless(metrics_add_sample(&m, TIMER, "zip", -1, 1.0, "prefix") == 0);
+    fail_unless(metrics_add_sample(&m, TIMER, "zip", 50, 1.0, "prefix") == 0);
 
     int okay = 0;
     fail_unless(metrics_iter(&m, (void*)&okay, iter_test_histogram) == 0);
@@ -214,11 +214,11 @@ START_TEST(test_metrics_gauges)
     int res = init_metrics_defaults(&m);
     fail_unless(res == 0);
 
-    fail_unless(metrics_add_sample(&m, GAUGE, "g1", 1, 1.0) == 0);
-    fail_unless(metrics_add_sample(&m, GAUGE_DELTA, "g1", 41, 1.0) == 0);
+    fail_unless(metrics_add_sample(&m, GAUGE, "g1", 1, 1.0, "prefix") == 0);
+    fail_unless(metrics_add_sample(&m, GAUGE_DELTA, "g1", 41, 1.0, "prefix") == 0);
 
-    fail_unless(metrics_add_sample(&m, GAUGE_DELTA, "g2", 100, 1.0) == 0);
-    fail_unless(metrics_add_sample(&m, GAUGE_DELTA, "g3", -100, 1.0) == 0);
+    fail_unless(metrics_add_sample(&m, GAUGE_DELTA, "g2", 100, 1.0, "prefix") == 0);
+    fail_unless(metrics_add_sample(&m, GAUGE_DELTA, "g3", -100, 1.0, "prefix") == 0);
 
     int okay = 0;
     fail_unless(metrics_iter(&m, (void*)&okay, iter_test_gauge) == 0);

--- a/tests/test_streaming.c
+++ b/tests/test_streaming.c
@@ -71,14 +71,14 @@ START_TEST(test_stream_some)
     fail_unless(res == 0);
 
     // Add some metrics
-    fail_unless(metrics_add_sample(&m, KEY_VAL, "test", 100, 1.0) == 0);
-    fail_unless(metrics_add_sample(&m, KEY_VAL, "test2", 42, 1.0) == 0);
-    fail_unless(metrics_add_sample(&m, COUNTER, "foo", 4, 1.0) == 0);
-    fail_unless(metrics_add_sample(&m, COUNTER, "foo", 6, 1.0) == 0);
-    fail_unless(metrics_add_sample(&m, COUNTER, "bar", 10, 1.0) == 0);
-    fail_unless(metrics_add_sample(&m, COUNTER, "bar", 20, 1.0) == 0);
-    fail_unless(metrics_add_sample(&m, TIMER, "baz", 1, 1.0) == 0);
-    fail_unless(metrics_add_sample(&m, TIMER, "baz", 10, 1.0) == 0);
+    fail_unless(metrics_add_sample(&m, KEY_VAL, "test", 100, 1.0, "prefix") == 0);
+    fail_unless(metrics_add_sample(&m, KEY_VAL, "test2", 42, 1.0, "prefix") == 0);
+    fail_unless(metrics_add_sample(&m, COUNTER, "foo", 4, 1.0, "prefix") == 0);
+    fail_unless(metrics_add_sample(&m, COUNTER, "foo", 6, 1.0, "prefix") == 0);
+    fail_unless(metrics_add_sample(&m, COUNTER, "bar", 10, 1.0, "prefix") == 0);
+    fail_unless(metrics_add_sample(&m, COUNTER, "bar", 20, 1.0, "prefix") == 0);
+    fail_unless(metrics_add_sample(&m, TIMER, "baz", 1, 1.0, "prefix") == 0);
+    fail_unless(metrics_add_sample(&m, TIMER, "baz", 10, 1.0, "prefix") == 0);
 
     int called = 0;
     res = stream_to_command(&m, &called, some_cb, "cat > /tmp/stream_some");
@@ -111,14 +111,14 @@ START_TEST(test_stream_bad_cmd)
     fail_unless(res == 0);
 
     // Add some metrics
-    fail_unless(metrics_add_sample(&m, KEY_VAL, "test", 100, 1.0) == 0);
-    fail_unless(metrics_add_sample(&m, KEY_VAL, "test2", 42, 1.0) == 0);
-    fail_unless(metrics_add_sample(&m, COUNTER, "foo", 4, 1.0) == 0);
-    fail_unless(metrics_add_sample(&m, COUNTER, "foo", 6, 1.0) == 0);
-    fail_unless(metrics_add_sample(&m, COUNTER, "bar", 10, 1.0) == 0);
-    fail_unless(metrics_add_sample(&m, COUNTER, "bar", 20, 1.0) == 0);
-    fail_unless(metrics_add_sample(&m, TIMER, "baz", 1, 1.0) == 0);
-    fail_unless(metrics_add_sample(&m, TIMER, "baz", 10, 1.0) == 0);
+    fail_unless(metrics_add_sample(&m, KEY_VAL, "test", 100, 1.0, "prefix") == 0);
+    fail_unless(metrics_add_sample(&m, KEY_VAL, "test2", 42, 1.0, "prefix") == 0);
+    fail_unless(metrics_add_sample(&m, COUNTER, "foo", 4, 1.0, "prefix") == 0);
+    fail_unless(metrics_add_sample(&m, COUNTER, "foo", 6, 1.0, "prefix") == 0);
+    fail_unless(metrics_add_sample(&m, COUNTER, "bar", 10, 1.0, "prefix") == 0);
+    fail_unless(metrics_add_sample(&m, COUNTER, "bar", 20, 1.0, "prefix") == 0);
+    fail_unless(metrics_add_sample(&m, TIMER, "baz", 1, 1.0, "prefix") == 0);
+    fail_unless(metrics_add_sample(&m, TIMER, "baz", 10, 1.0, "prefix") == 0);
 
     int called = 0;
     res = stream_to_command(&m, &called, some_cb, "abcd 2>/dev/null");
@@ -136,14 +136,14 @@ START_TEST(test_stream_sigpipe)
     fail_unless(res == 0);
 
     // Add some metrics
-    fail_unless(metrics_add_sample(&m, KEY_VAL, "test", 100, 1.0) == 0);
-    fail_unless(metrics_add_sample(&m, KEY_VAL, "test2", 42, 1.0) == 0);
-    fail_unless(metrics_add_sample(&m, COUNTER, "foo", 4, 1.0) == 0);
-    fail_unless(metrics_add_sample(&m, COUNTER, "foo", 6, 1.0) == 0);
-    fail_unless(metrics_add_sample(&m, COUNTER, "bar", 10, 1.0) == 0);
-    fail_unless(metrics_add_sample(&m, COUNTER, "bar", 20, 1.0) == 0);
-    fail_unless(metrics_add_sample(&m, TIMER, "baz", 1, 1.0) == 0);
-    fail_unless(metrics_add_sample(&m, TIMER, "baz", 10, 1.0) == 0);
+    fail_unless(metrics_add_sample(&m, KEY_VAL, "test", 100, 1.0, "prefix") == 0);
+    fail_unless(metrics_add_sample(&m, KEY_VAL, "test2", 42, 1.0, "prefix") == 0);
+    fail_unless(metrics_add_sample(&m, COUNTER, "foo", 4, 1.0, "prefix") == 0);
+    fail_unless(metrics_add_sample(&m, COUNTER, "foo", 6, 1.0, "prefix") == 0);
+    fail_unless(metrics_add_sample(&m, COUNTER, "bar", 10, 1.0, "prefix") == 0);
+    fail_unless(metrics_add_sample(&m, COUNTER, "bar", 20, 1.0, "prefix") == 0);
+    fail_unless(metrics_add_sample(&m, TIMER, "baz", 1, 1.0, "prefix") == 0);
+    fail_unless(metrics_add_sample(&m, TIMER, "baz", 10, 1.0, "prefix") == 0);
 
     int called = 0;
     res = stream_to_command(&m, &called, some_cb, "head -n1 >/dev/null");


### PR DESCRIPTION
implemented some internal metrics to help get visibility.

requires new config for "metrics_prefix"

```
[statsite]
port = 8125
udp_port = 8125
log_level = DEBUG
flush_interval = 10
timer_eps = 0.01
stream_cmd=python /usr/local/share/statsite/sinks/graphite.py graphite 2003 metrics.
global_prefix = application.
use_type_prefix = 0
extended_counters = true
quantiles = 0.5, 0.95, 0.99
legacy_extended_counters = false
metrics_prefix = statsite.
```

